### PR TITLE
Demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Elles convertissent les arguments de type `pathlib.Path` en `str` puisque
 ### Démo
 
 Le script dans le dossier `demo` montre comment `syspathmodif` permet
-d'importer un paquet indisponible sans l'ajout d'un chemin à `sys.path`.
+d'importer un paquet indisponible sans l'ajout de son chemin à `sys.path`.
 Il dépend du paquet `demo_package`.
 Lancez la démo avec la commande suivante.
 
@@ -56,7 +56,7 @@ supposed to contain only character strings.
 ### Demo
 
 The script in directory `demo` shows how `syspathmodif` allows to import a
-package unavailable without adding a path to `sys.path`.
+package unavailable unless its path is added to `sys.path`.
 It depends on `demo_package`.
 Run the demo with the following command.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ Elles convertissent les arguments de type `pathlib.Path` en `str` puisque
 * `sp_contains` indique si `sys.path` contient le chemin donné.
 * `sp_remove` enlève le chemin donné de `sys.path`.
 
+### Démo
+
+Le script dans le dossier `demo` montre comment `syspathmodif` permet
+d'importer un paquet indisponible sans l'ajout d'un chemin à `sys.path`.
+Il dépend du paquet `demo_package`.
+Lancez la démo avec la commande suivante.
+
+```
+python demo/demo.py
+```
+
 ### Tests automatiques
 
 Installez `pytest`.
@@ -41,6 +52,17 @@ supposed to contain only character strings.
 * `sp_append` appends the given path to the end of `sys.path`.
 * `sp_contains` indicates whether `sys.path` contains the given path.
 * `sp_remove` removes the given path from `sys.path`.
+
+### Demo
+
+The script in directory `demo` shows how `syspathmodif` allows to import a
+package unavailable without adding a path to `sys.path`.
+It depends on `demo_package`.
+Run the demo with the following command.
+
+```
+python demo/demo.py
+```
 
 ### Automated Tests
 

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -22,6 +22,7 @@ _print_sys_path(
 	"\nRepository root appended to sys.path to import package syspathmodif")
 from syspathmodif import\
 	sp_append,\
+	sp_contains,\
 	sp_remove
 sys.path = list(_INIT_SYS_PATH)
 _print_sys_path("\nsys.path reset after the importation")
@@ -35,6 +36,7 @@ _print_sys_path(
 from demo_package import\
 	Ajxo,\
 	Point
+print(f"\nsys.path contains the repository's root: {sp_contains(_REPO_ROOT)}")
 sp_remove(_REPO_ROOT)
 _print_sys_path(
 	"\nRepository root removed from sys.path after the importation")

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+import sys
+
+
+_NEW_LINE = "\n"
+
+
+def _print_sys_path(title):
+	print(title + _NEW_LINE + _NEW_LINE.join(sys.path))
+
+
+_INIT_SYS_PATH = list(sys.path)
+_print_sys_path("Initial sys.path content")
+
+_LOCAL_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _LOCAL_DIR.parent
+
+
+# syspathmodif is imported here.
+sys.path.append(str(_REPO_ROOT))
+_print_sys_path(
+	"\nRepository root appended to sys.path to import package syspathmodif")
+from syspathmodif import\
+	sp_append,\
+	sp_remove
+sys.path = list(_INIT_SYS_PATH)
+_print_sys_path("\nsys.path reset after the importation")
+# End of syspathmodif's importation
+
+
+# syspathmodif is used here.
+sp_append(_REPO_ROOT)
+_print_sys_path(
+	"\nRepository root appended to sys.path to import demo_package")
+from demo_package import\
+	Ajxo,\
+	Point
+sp_remove(_REPO_ROOT)
+_print_sys_path(
+	"\nRepository root removed from sys.path after the importation")
+# End of syspathmodif's use
+
+
+ajxo = Ajxo("a string", [7, 11, 13])
+point = Point(41, 97)
+
+print("\nInstances of imported classes")
+print(ajxo)
+print(point)
+
+print(f"\nsys.path is the same as before the demo: "\
+		+ str(sys.path == _INIT_SYS_PATH))

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -30,6 +30,7 @@ _print_sys_path("\nsys.path reset after the importation")
 
 
 # syspathmodif is used here.
+print(f"\nsys.path contains the repository's root: {sp_contains(_REPO_ROOT)}")
 sp_append(_REPO_ROOT)
 _print_sys_path(
 	"\nRepository root appended to sys.path to import demo_package")
@@ -40,6 +41,7 @@ print(f"\nsys.path contains the repository's root: {sp_contains(_REPO_ROOT)}")
 sp_remove(_REPO_ROOT)
 _print_sys_path(
 	"\nRepository root removed from sys.path after the importation")
+print(f"\nsys.path contains the repository's root: {sp_contains(_REPO_ROOT)}")
 # End of syspathmodif's use
 
 

--- a/demo_package/__init__.py
+++ b/demo_package/__init__.py
@@ -1,0 +1,2 @@
+from .ajxo import Ajxo
+from .point import Point

--- a/demo_package/ajxo.py
+++ b/demo_package/ajxo.py
@@ -1,0 +1,10 @@
+class Ajxo:
+	# "Ajxo" means "thing" in Esperanto.
+
+	def __init__(self, a, b):
+		self.a = a
+		self.b = b
+
+	def __repr__(self):
+		return self.__class__.__name__\
+			+ "(" + repr(self.a) + ", " + repr(self.b) + ")"

--- a/demo_package/point.py
+++ b/demo_package/point.py
@@ -1,0 +1,17 @@
+class Point:
+
+	def __init__(self, x, y):
+		self._x = x
+		self._y = y
+
+	def __repr__(self):
+		return self.__class__.__name__\
+			+ "(" + str(self._x) + ", " + str(self._y) + ")"
+
+	@property
+	def x(self):
+		return self._x
+
+	@property
+	def y(self):
+		return self._y

--- a/syspathmodif/syspathmodif.py
+++ b/syspathmodif/syspathmodif.py
@@ -2,9 +2,6 @@ from pathlib import Path
 import sys
 
 
-_SYS_PATH = sys.path
-
-
 def sp_append(some_path):
 	"""
 	Appends the given path to the end of list sys.path if it does not already
@@ -19,8 +16,8 @@ def sp_append(some_path):
 	"""
 	some_path = _ensure_path_is_str(some_path)
 
-	if some_path not in _SYS_PATH:
-		_SYS_PATH.append(some_path)
+	if some_path not in sys.path:
+		sys.path.append(some_path)
 
 
 def sp_contains(some_path):
@@ -37,7 +34,7 @@ def sp_contains(some_path):
 		TypeError: if argument some_path is not of type str or pathlib.Path.
 	"""
 	some_path = _ensure_path_is_str(some_path)
-	return some_path in _SYS_PATH
+	return some_path in sys.path
 
 
 def sp_remove(some_path):
@@ -52,8 +49,8 @@ def sp_remove(some_path):
 	"""
 	some_path = _ensure_path_is_str(some_path)
 
-	if some_path in _SYS_PATH:
-		_SYS_PATH.remove(some_path)
+	if some_path in sys.path:
+		sys.path.remove(some_path)
 
 
 def _ensure_path_is_str(some_path):


### PR DESCRIPTION
The demo shows how `syspathmodif` allows to import a package unavailable unless its path is added to `sys.path`.