### PR TITLE
A CI job tests the PyPI package's build

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -24,5 +24,5 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v2
       - name: Test the build
-        run: python3 test_pypi_package_build.py
+        run: python3 .github/workflows/test_pypi_package_build.py
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -18,3 +18,11 @@ jobs:
         run: pip3 install --no-cache-dir -r requirements-dev.txt
       - name: Execute unit tests
         run: pytest tests/test_syspathmodif.py
+  test_pypi_package_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Test the build
+	    run: test_pypi_package_build.py
+

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -24,5 +24,5 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v2
       - name: Test the build
-        run: test_pypi_package_build.py
+        run: python3 test_pypi_package_build.py
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -24,5 +24,5 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v2
       - name: Test the build
-	    run: test_pypi_package_build.py
+        run: test_pypi_package_build.py
 

--- a/.github/workflows/test_pypi_package_build.py
+++ b/.github/workflows/test_pypi_package_build.py
@@ -1,0 +1,18 @@
+#!/bin/python3
+
+from os import system
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# This script builds the PyPI package and installs it to ensure the
+# installation works. However, the script does not upload the package to PyPI.
+
+system(f"python3 {_REPO_ROOT}/setup.py sdist")
+
+latest_dist = (_REPO_ROOT/"dist").glob("syspathmodif-*.tar.gz")[-1]
+
+system(f"pip3 install --no-cache-dir {latest_dist}")
+

--- a/.github/workflows/test_pypi_package_build.py
+++ b/.github/workflows/test_pypi_package_build.py
@@ -12,7 +12,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 system(f"python3 {_REPO_ROOT}/setup.py sdist")
 
-latest_dist = (_REPO_ROOT/"dist").glob("syspathmodif-*.tar.gz")[-1]
+latest_dist = list((_REPO_ROOT/"dist").glob("syspathmodif-*.tar.gz"))[-1]
 
 system(f"pip3 install --no-cache-dir {latest_dist}")
 


### PR DESCRIPTION
The new CI workflow job builds the PyPI package and installs it to ensure the installation works. However, the job does not upload the package to PyPI.