### PR TITLE
`SysPathBundle` is a context manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ les ajoute à `sys.path`. Quand on vide (*clear*) une instance, elle efface son
 contenu et l'enlève de `sys.path`. Ainsi, cette classe facilite l'ajout et le
 retrait d'un groupe de chemins.
 
+Il est possible d'utiliser `SysPathBundle` comme un gestionnaire de contexte
+(*context manager*). Dans ce cas, l'instance est vidée à la fin du bloc `with`.
+
 Pour plus d'informations, consultez la documentation des fonctions et les démos
 dans le dépôt de code source.
 
@@ -42,13 +45,19 @@ pip install -r requirements-dev.txt
 
 Les scripts dans le dossier `demos` montrent comment `syspathmodif` permet
 d'importer un paquet qui est indisponible tant qu'on n'a pas ajouté son chemin
-à `sys.path`. Les deux démos dépendent du paquet `demo_package`.
+à `sys.path`. Toutes les démos dépendent du paquet `demo_package`.
 
 À l'aide de la classe `SysPathBundle`, `demo_bundle.py` ajoute la racine du
-dépôt et `demo_package` à `sys.path`. La suppression de l'instance de
-`SysPathBundle` annule cette modification.
+dépôt et `demo_package` à `sys.path`. Ensuite, la démo annule cette
+modification en vidant l'instance de `SysPathBundle`.
 ```
 python demos/demo_bundle.py
+```
+
+En utilisant `SysPathBundle` comme un gestionnaire de contexte,
+`demo_bundle_context.py` effectue la même tâche que `demo_bundle.py`.
+```
+python demos/demo_bundle_context.py
 ```
 
 À l'aide des fonctions `sp_append` et `sp_remove`, `demo_functions.py` ajoute
@@ -84,6 +93,9 @@ Upon instantiation, class `SysPathBundle` stores several paths and adds them to
 `sys.path`. When a bundle is cleared, it erases its content and removes it from
 `sys.path`. Thus, this class facilitates adding and removing a group of paths.
 
+`SysPathBundle` can be used as a context manager. In that case, the instance is
+cleared at the `with` block's end.
+
 For more information, consult the functions' documentation and the demos in the
 source code repository.
 
@@ -103,14 +115,20 @@ pip install -r requirements-dev.txt
 ### Demos
 
 The scripts in directory `demos` show how `syspathmodif` allows to import a
-package unavailable unless its path is added to `sys.path`. Both demos depend
+package unavailable unless its path is added to `sys.path`. All demos depend
 on `demo_package`.
 
 With class `SysPathBundle`, `demo_bundle.py` adds the repository's root and
-`demo_package` to `sys.path`. The deletion of the `SysPathBundle` instance
-undoes this modification.
+`demo_package` to `sys.path`. Afterward, the demo undoes this modification by
+clearing the `SysPathBundle` instance.
 ```
 python demos/demo_bundle.py
+```
+
+By using `SysPathBundle` as a context manager, `demo_bundle_context.py`
+performs the same task as `demo_bundle.py`.
+```
+python demos/demo_bundle_context.py
 ```
 
 With functions `sp_append` and `sp_remove`, `demo_functions.py` adds the

--- a/README.md
+++ b/README.md
@@ -47,21 +47,22 @@ Les scripts dans le dossier `demos` montrent comment `syspathmodif` permet
 d'importer un paquet qui est indisponible tant qu'on n'a pas ajouté son chemin
 à `sys.path`. Toutes les démos dépendent du paquet `demo_package`.
 
-À l'aide de la classe `SysPathBundle`, `demo_bundle.py` ajoute la racine du
-dépôt et `demo_package` à `sys.path`. Ensuite, la démo annule cette
-modification en vidant l'instance de `SysPathBundle`.
+`demo_bundle.py` ajoute la racine du dépôt et `demo_package` à `sys.path` à
+l'aide de la classe `SysPathBundle`. Après les importations, la démo annule
+cette modification en vidant l'instance de `SysPathBundle`.
 ```
 python demos/demo_bundle.py
 ```
 
-En utilisant `SysPathBundle` comme un gestionnaire de contexte,
-`demo_bundle_context.py` effectue la même tâche que `demo_bundle.py`.
+`demo_bundle_context.py` effectue la même tâche que `demo_bundle.py` en
+utilisant `SysPathBundle` comme un gestionnaire de contexte.
 ```
 python demos/demo_bundle_context.py
 ```
 
-À l'aide des fonctions `sp_append` et `sp_remove`, `demo_functions.py` ajoute
-la racine du dépôt à `sys.path` puis l'en enlève.
+`demo_functions.py` ajoute la racine du dépôt à `sys.path` à l'aide de la
+fonction `sp_append`. Après les importations, la démo annule cette modification
+à l'aide de la fonction `sp_remove`.
 ```
 python demos/demo_functions.py
 ```
@@ -118,21 +119,22 @@ The scripts in directory `demos` show how `syspathmodif` allows to import a
 package unavailable unless its path is added to `sys.path`. All demos depend
 on `demo_package`.
 
-With class `SysPathBundle`, `demo_bundle.py` adds the repository's root and
-`demo_package` to `sys.path`. Afterward, the demo undoes this modification by
-clearing the `SysPathBundle` instance.
+`demo_bundle.py` adds the repository's root and `demo_package` to `sys.path`
+with class `SysPathBundle`. After the imports, the demo undoes this
+modification by clearing the `SysPathBundle` instance.
 ```
 python demos/demo_bundle.py
 ```
 
-By using `SysPathBundle` as a context manager, `demo_bundle_context.py`
-performs the same task as `demo_bundle.py`.
+`demo_bundle_context.py` performs the same task as `demo_bundle.py` by using
+`SysPathBundle` as a context manager.
 ```
 python demos/demo_bundle_context.py
 ```
 
-With functions `sp_append` and `sp_remove`, `demo_functions.py` adds the
-repository's root to `sys.path` then removes it.
+`demo_functions.py` adds the repository's root to `sys.path` with function
+`sp_append`. After the imports, the demo undoes this modification with function
+`sp_remove`.
 ```
 python demos/demo_functions.py
 ```

--- a/demos/demo_bundle_context.py
+++ b/demos/demo_bundle_context.py
@@ -1,0 +1,65 @@
+import sys
+
+from _demo_util import\
+	INIT_SYS_PATH,\
+	DEMO_DIR,\
+	REPO_ROOT,\
+	print_sys_path,\
+	reset_sys_path
+
+
+_PACKAGE_DIR = REPO_ROOT/"demo_package"
+
+print_sys_path("sys.path's initial content")
+
+print(f"\nDemo directory: {DEMO_DIR}")
+print(f"Repository root: {REPO_ROOT}")
+print(f"Package: {_PACKAGE_DIR}")
+
+
+# Imports from syspathmodif are performed here.
+sys.path.append(str(REPO_ROOT))
+
+print_sys_path(
+	"\nRepository root appended to sys.path to import package syspathmodif")
+
+from syspathmodif import\
+	SysPathBundle,\
+	sp_contains
+
+reset_sys_path()
+print_sys_path("\nsys.path reset after the importation")
+# End of imports from syspathmodif
+
+
+# SysPathBundle is used here.
+print(f"\nsys.path contains the repository's root: {sp_contains(REPO_ROOT)}")
+print(f"sys.path contains the package's directory: {sp_contains(_PACKAGE_DIR)}")
+
+with SysPathBundle((REPO_ROOT, _PACKAGE_DIR)):
+	print_sys_path(
+		"\nPaths appended to sys.path to import from demo_package")
+
+	from demo_package import Ajxo
+	from point import Point
+
+	print(f"\nsys.path contains the repository's root: {sp_contains(REPO_ROOT)}")
+	print(f"sys.path contains the package's directory: {sp_contains(_PACKAGE_DIR)}")
+
+print_sys_path(
+	"\nPaths removed from sys.path after the imports")
+
+print(f"\nsys.path contains the repository's root: {sp_contains(REPO_ROOT)}")
+print(f"sys.path contains the package's directory: {sp_contains(_PACKAGE_DIR)}")
+# End of SysPathBundle's use
+
+
+ajxo = Ajxo("a string", [7, 11, 13])
+point = Point(41, 97)
+
+print("\nInstances of imported classes")
+print(ajxo)
+print(point)
+
+print("\nsys.path is the same as before the demo: "\
+		+ str(sys.path == INIT_SYS_PATH))

--- a/syspathmodif/_syspathbundle.py
+++ b/syspathmodif/_syspathbundle.py
@@ -49,6 +49,24 @@ class SysPathBundle:
 			path = self._content.pop()
 			sp_remove_no_path_check(path)
 
+	def contains(self, some_path):
+		"""
+		Indicates whether this bundle cotains the given path.
+
+		Args:
+			some_path (str or pathlib.Path): the path whose presence is
+				verified.
+
+		Returns:
+			bool: True if this bundle cotains the given path, False otherwise.
+
+		Raises:
+			TypeError: if a path is not None and not of type str or
+				pathlib.Path.
+		"""
+		some_path = ensure_path_is_str(some_path, True)
+		return some_path in self._content
+
 	def _fill_content(self, content):
 		for path in content:
 			path = ensure_path_is_str(path, True)

--- a/syspathmodif/_syspathbundle.py
+++ b/syspathmodif/_syspathbundle.py
@@ -12,8 +12,8 @@ class SysPathBundle:
 	from sys.path. Thus, this class facilitates adding and removing a group of
 	paths.
 
-	This class is a context manager. It can be used in a with block as in the
-	following example.
+	This class is a context manager. If a bundle is used in a with statement as
+	in the following example, it is cleared at the block's end.
 
 	with SysPathBundle(("path/to/package1", "path/to/package2")):
 	"""

--- a/syspathmodif/_syspathbundle.py
+++ b/syspathmodif/_syspathbundle.py
@@ -12,7 +12,10 @@ class SysPathBundle:
 	from sys.path. Thus, this class facilitates adding and removing a group of
 	paths.
 
-	The destructor __del__ clears the bundles.
+	This class is a context manager. It can be used in a with block as in the
+	following example.
+
+	with SysPathBundle(("path/to/package1", "path/to/package2")):
 	"""
 
 	def __init__(self, content):
@@ -32,10 +35,10 @@ class SysPathBundle:
 		self._content = list()
 		self._fill_content(content)
 
-	def __del__(self):
-		"""
-		Clears the bundle by calling method clear.
-		"""
+	def __enter__(self):
+		return self
+
+	def __exit__(self, exc_type, exc_value, traceback):
 		self.clear()
 
 	def clear(self):

--- a/tests/test_syspathbundle.py
+++ b/tests/test_syspathbundle.py
@@ -32,12 +32,17 @@ def assert_path_is_present(some_path, bundle, is_in_sys_path, is_in_bundle):
 	assert bundle.contains(some_path) == is_in_bundle
 
 
+def generate_paths():
+	yield _LOCAL_DIR
+	yield _REPO_ROOT
+	yield _LIB_DIR
+
+
 def test_init_generator():
 	try:
 		from inspect import isgenerator
 
-		content = (_LOCAL_DIR, _REPO_ROOT, _LIB_DIR)
-		content_gen = (path for path in content)
+		content_gen = generate_paths()
 		assert isgenerator(content_gen)
 		bundle = SysPathBundle(content_gen)
 

--- a/tests/test_syspathbundle.py
+++ b/tests/test_syspathbundle.py
@@ -106,10 +106,12 @@ def test_clear():
 		_reset_sys_path()
 
 
-def test_del():
+def test_context_management():
 	try:
-		bundle = SysPathBundle((_LOCAL_DIR, _REPO_ROOT, _LIB_DIR))
-		del bundle
+		with SysPathBundle((_LOCAL_DIR, _REPO_ROOT, _LIB_DIR)) as bundle:
+			assert_path_is_present(_LOCAL_DIR, bundle, True, False)
+			assert_path_is_present(_REPO_ROOT, bundle, True, True)
+			assert_path_is_present(_LIB_DIR, bundle, True, True)
 
 		assert_path_in_sys_path(_LOCAL_DIR, True)
 		assert_path_in_sys_path(_REPO_ROOT, False)

--- a/tests/test_syspathbundle.py
+++ b/tests/test_syspathbundle.py
@@ -29,7 +29,7 @@ def assert_path_in_sys_path(some_path, is_in_sys_path):
 def assert_path_is_present(some_path, bundle, is_in_sys_path, is_in_bundle):
 	some_path = ensure_path_is_str(some_path, True)
 	assert (some_path in sys.path) == is_in_sys_path
-	assert (some_path in bundle._content) == is_in_bundle
+	assert bundle.contains(some_path) == is_in_bundle
 
 
 def test_init_generator():


### PR DESCRIPTION
If a bundle is used in a `with` statement, it is cleared at the block's end. `SysPathBundle`'s destructor was removed.