### PR TITLE
`SysPathBundle` has method `__repr__`

### DIFF
--- a/demos/demo_bundle.py
+++ b/demos/demo_bundle.py
@@ -36,6 +36,7 @@ print_sys_path("\nsys.path reset after the importation")
 print(f"\nsys.path contains the repository's root: {sp_contains(REPO_ROOT)}")
 print(f"sys.path contains the package's directory: {sp_contains(_PACKAGE_DIR)}")
 
+# The bundle adds the paths to sys.path.
 bundle = SysPathBundle((REPO_ROOT, _PACKAGE_DIR))
 print_sys_path(
 	"\nPaths appended to sys.path to import from demo_package")
@@ -46,7 +47,8 @@ from point import Point
 print(f"\nsys.path contains the repository's root: {sp_contains(REPO_ROOT)}")
 print(f"sys.path contains the package's directory: {sp_contains(_PACKAGE_DIR)}")
 
-# Paths removed by __del__ when the garbage collector destroys the bundle.
+# Clearing the bundle removes the paths from sys.path.
+bundle.clear()
 del bundle
 print_sys_path(
 	"\nPaths removed from sys.path after the imports")

--- a/demos/demo_bundle.py
+++ b/demos/demo_bundle.py
@@ -65,5 +65,6 @@ print("\nInstances of imported classes")
 print(ajxo)
 print(point)
 
-print("\nsys.path is the same as before the demo: "\
-		+ str(sys.path == INIT_SYS_PATH))
+is_sys_path_the_same = sys.path == INIT_SYS_PATH
+print(f"\nsys.path is the same as before the demo: {is_sys_path_the_same}")
+assert is_sys_path_the_same

--- a/demos/demo_bundle_context.py
+++ b/demos/demo_bundle_context.py
@@ -62,5 +62,6 @@ print("\nInstances of imported classes")
 print(ajxo)
 print(point)
 
-print("\nsys.path is the same as before the demo: "\
-		+ str(sys.path == INIT_SYS_PATH))
+is_sys_path_the_same = sys.path == INIT_SYS_PATH
+print(f"\nsys.path is the same as before the demo: {is_sys_path_the_same}")
+assert is_sys_path_the_same

--- a/demos/demo_bundle_context.py
+++ b/demos/demo_bundle_context.py
@@ -36,6 +36,7 @@ print_sys_path("\nsys.path reset after the importation")
 print(f"\nsys.path contains the repository's root: {sp_contains(REPO_ROOT)}")
 print(f"sys.path contains the package's directory: {sp_contains(_PACKAGE_DIR)}")
 
+# The bundle adds the paths to sys.path. It is cleared at the block's end.
 with SysPathBundle((REPO_ROOT, _PACKAGE_DIR)):
 	print_sys_path(
 		"\nPaths appended to sys.path to import from demo_package")

--- a/demos/demo_bundle_context.py
+++ b/demos/demo_bundle_context.py
@@ -36,7 +36,7 @@ print_sys_path("\nsys.path reset after the importation")
 print(f"\nsys.path contains the repository's root: {sp_contains(REPO_ROOT)}")
 print(f"sys.path contains the package's directory: {sp_contains(_PACKAGE_DIR)}")
 
-# The bundle adds the paths to sys.path. It is cleared at the block's end.
+# The bundle adds the paths to sys.path. The block's end clears the bundle.
 with SysPathBundle((REPO_ROOT, _PACKAGE_DIR)):
 	print_sys_path(
 		"\nPaths appended to sys.path to import from demo_package")

--- a/demos/demo_functions.py
+++ b/demos/demo_functions.py
@@ -57,5 +57,6 @@ print("\nInstances of imported classes")
 print(ajxo)
 print(point)
 
-print("\nsys.path is the same as before the demo: "\
-		+ str(sys.path == INIT_SYS_PATH))
+is_sys_path_the_same = sys.path == INIT_SYS_PATH
+print(f"\nsys.path is the same as before the demo: {is_sys_path_the_same}")
+assert is_sys_path_the_same

--- a/syspathmodif/_syspathbundle.py
+++ b/syspathmodif/_syspathbundle.py
@@ -41,6 +41,9 @@ class SysPathBundle:
 	def __exit__(self, exc_type, exc_value, traceback):
 		self.clear()
 
+	def __repr__(self):
+		return self.__class__.__name__ + f"({self._content})"
+
 	def clear(self):
 		"""
 		Erases this bundle's content and removes it from sys.path.


### PR DESCRIPTION
Also, the demos were adapted to the removal of `SysPathBundle`'s destructor. They assert `sys.path` is the same as before.