### PR TITLE
`SysPathBundle` instances can be cleared on deletion

### DIFF
--- a/demos/demo_bundle.py
+++ b/demos/demo_bundle.py
@@ -36,8 +36,8 @@ print_sys_path("\nsys.path reset after the importation")
 print(f"\nsys.path contains the repository's root: {sp_contains(REPO_ROOT)}")
 print(f"sys.path contains the package's directory: {sp_contains(_PACKAGE_DIR)}")
 
-# The bundle adds the paths to sys.path.
-bundle = SysPathBundle((REPO_ROOT, _PACKAGE_DIR))
+# The bundle adds the paths to sys.path. It will be cleared on deletion.
+bundle = SysPathBundle((REPO_ROOT, _PACKAGE_DIR), True)
 print_sys_path(
 	"\nPaths appended to sys.path to import from demo_package")
 
@@ -47,8 +47,7 @@ from point import Point
 print(f"\nsys.path contains the repository's root: {sp_contains(REPO_ROOT)}")
 print(f"sys.path contains the package's directory: {sp_contains(_PACKAGE_DIR)}")
 
-# Clearing the bundle removes the paths from sys.path.
-bundle.clear()
+# The destructor clears the bundle, removing the paths from sys.path.
 del bundle
 print_sys_path(
 	"\nPaths removed from sys.path after the imports")

--- a/syspathmodif/syspathbundle.py
+++ b/syspathmodif/syspathbundle.py
@@ -18,9 +18,13 @@ class SysPathBundle:
 	in the following example, it is cleared at the block's end.
 
 	with SysPathBundle(("path/to/module", "path/to/package")):
+	
+	The constructor can set a bundle to be cleared by the destructor. This
+	should not be done for a bundle used as a context manager as exiting the
+	with block clears the bundle anyway.
 	"""
 
-	def __init__(self, content):
+	def __init__(self, content, cleared_on_del=False):
 		"""
 		The constructor needs the paths (type str or pathlib.Path) to store in
 		this bundle and add to sys.path. If a path in argument content is
@@ -29,6 +33,9 @@ class SysPathBundle:
 		Args:
 			content (generator, list, set or tuple): the paths to store in this
 				bundle.
+			cleared_on_del (bool): If it is True, the destructor will clear
+				this bundle. Should be False if the bundle is used as a context
+				manger. Defaults to False.
 
 		Raises:
 			TypeError: if a path is not None and not of type str or
@@ -37,6 +44,15 @@ class SysPathBundle:
 		self._content = list()
 		self._fill_content(content)
 
+		self._cleared_on_del = cleared_on_del
+
+	def __del__(self):
+		"""
+		The destructor will clear this bundle if property cleared_on_del is True.
+		"""
+		if self._cleared_on_del:
+			self.clear()
+
 	def __enter__(self):
 		return self
 
@@ -44,7 +60,19 @@ class SysPathBundle:
 		self.clear()
 
 	def __repr__(self):
-		return self.__class__.__name__ + f"({self._content})"
+		return self.__class__.__name__\
+			+ f"({self._content}, {self._cleared_on_del})"
+
+	@property
+	def cleared_on_del(self):
+		"""
+		bool: If this property is True, the destructor will clear this bundle.
+		"""
+		return self._cleared_on_del
+
+	@cleared_on_del.setter
+	def cleared_on_del(self, value):
+		self._cleared_on_del = value
 
 	def clear(self):
 		"""

--- a/tests/test_syspathbundle.py
+++ b/tests/test_syspathbundle.py
@@ -115,6 +115,22 @@ def test_clear():
 		_reset_sys_path()
 
 
+def test_cleared_on_del():
+	try:
+		bundle = SysPathBundle((_LOCAL_DIR, _REPO_ROOT, _LIB_DIR), True)
+		assert bundle.cleared_on_del
+		del bundle
+
+		assert_path_in_sys_path(_LOCAL_DIR, True)
+		assert_path_in_sys_path(_REPO_ROOT, False)
+		assert_path_in_sys_path(_LIB_DIR, False)
+
+		assert sys.path == _INIT_SYS_PATH
+
+	finally:
+		_reset_sys_path()
+
+
 def test_context_management():
 	try:
 		with SysPathBundle((_LOCAL_DIR, _REPO_ROOT, _LIB_DIR)) as bundle:

--- a/tests/test_syspathbundle.py
+++ b/tests/test_syspathbundle.py
@@ -45,6 +45,7 @@ def test_init_generator():
 		content_gen = generate_paths()
 		assert isgenerator(content_gen)
 		bundle = SysPathBundle(content_gen)
+		assert not bundle.cleared_on_del
 
 		assert_path_is_present(_LOCAL_DIR, bundle, True, False)
 		assert_path_is_present(_REPO_ROOT, bundle, True, True)
@@ -59,6 +60,7 @@ def test_init_list():
 		content = [_LOCAL_DIR, _REPO_ROOT, _LIB_DIR]
 		assert isinstance(content, list)
 		bundle = SysPathBundle(content)
+		assert not bundle.cleared_on_del
 
 		assert_path_is_present(_LOCAL_DIR, bundle, True, False)
 		assert_path_is_present(_REPO_ROOT, bundle, True, True)
@@ -73,6 +75,7 @@ def test_init_tuple():
 		content = (_LOCAL_DIR, _REPO_ROOT, _LIB_DIR)
 		assert isinstance(content, tuple)
 		bundle = SysPathBundle(content)
+		assert not bundle.cleared_on_del
 
 		assert_path_is_present(_LOCAL_DIR, bundle, True, False)
 		assert_path_is_present(_REPO_ROOT, bundle, True, True)
@@ -87,6 +90,7 @@ def test_init_set():
 		content = {_LOCAL_DIR, _REPO_ROOT, _LIB_DIR}
 		assert isinstance(content, set)
 		bundle = SysPathBundle(content)
+		assert not bundle.cleared_on_del
 
 		assert_path_is_present(_LOCAL_DIR, bundle, True, False)
 		assert_path_is_present(_REPO_ROOT, bundle, True, True)


### PR DESCRIPTION
`SysPathBundle.__del__` calls `SysPathBundle.clear` if property `SysPathBundle.cleared_on_del` is `True`.