### PR TITLE
Bundle content cleared if an exception is raised

### DIFF
--- a/.github/workflows/test_pypi_package_build.py
+++ b/.github/workflows/test_pypi_package_build.py
@@ -14,6 +14,6 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 system(f"python3 {_REPO_ROOT}/setup.py sdist")
 
-latest_dist = next((_REPO_ROOT/"dist").glob("syspathmodif-*.tar.gz"))
+src_dist = next((_REPO_ROOT/"dist").glob("syspathmodif-*.tar.gz"))
 
-system(f"pip3 install --no-cache-dir {latest_dist}")
+system(f"pip3 install --no-cache-dir {src_dist}")

--- a/.github/workflows/test_pypi_package_build.py
+++ b/.github/workflows/test_pypi_package_build.py
@@ -14,6 +14,6 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 system(f"python3 {_REPO_ROOT}/setup.py sdist")
 
-latest_dist = list((_REPO_ROOT/"dist").glob("syspathmodif-*.tar.gz"))[-1]
+latest_dist = next((_REPO_ROOT/"dist").glob("syspathmodif-*.tar.gz"))
 
 system(f"pip3 install --no-cache-dir {latest_dist}")

--- a/syspathmodif/syspathbundle.py
+++ b/syspathmodif/syspathbundle.py
@@ -86,6 +86,7 @@ class SysPathBundle:
 			except AttributeError:
 				# If a bundle is cleared by the destructor when
 				# the application ends, sys.path can be None.
+				self._content.clear()
 				break
 
 	def contains(self, some_path):


### PR DESCRIPTION
If `SysPathBundle.clear` catches an `AttributeError`, it clears list `SysPathBundle._content`.