### PR TITLE
Function `sm_contains`

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -27,8 +27,12 @@ jobs:
         run: pip3 install --no-cache-dir -r requirements.txt
       - name: Run the SysPathBundle demo
         run: python3 demos/demo_bundle.py
+      - name: Run the SysPathBundle context manager demo
+        run: python3 demos/demo_bundle_context.py
       - name: Run the functions' demo
         run: python3 demos/demo_functions.py
+      - name: Run the sm_contains demo
+        run: python3 demos/demo_sm_contains.py
   test_bundle_clearing_app_end:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -31,8 +31,10 @@ jobs:
         run: python3 demos/demo_bundle_context.py
       - name: Run the functions' demo
         run: python3 demos/demo_functions.py
-      - name: Run the sm_contains demo
-        run: python3 demos/demo_sm_contains.py
+      - name: Run the first sm_contains demo
+        run: python3 demos/demo_sm_contains1.py
+      - name: Run the second sm_contains demo
+        run: python3 demos/demo_sm_contains2.py
   test_bundle_clearing_app_end:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ liste.
 ### Importations et `sys.path`
 
 Il est possible d'importer un module ou un paquet si la liste `sys.path`
-contient le chemin de son dossier. Si un module ou un paquet n'est pas
-importable, il peut le devenir si on ajoute le chemin de son dossier à
-`sys.path`.
+contient le chemin de son dossier. On peut donc rendre un module ou un paquet
+importable en ajoutant le chemin de son dossier à `sys.path`.
 
 ### Contenu
 
@@ -114,8 +113,8 @@ The user should not need to directly interact with that list.
 ### Imports and `sys.path`
 
 It is possible to import a module or package if list `sys.path` contains the
-path to its directory. A module or package will become importable if the path
-to its directory is added to `sys.path`.
+path to its directory. Therefore, you can make a module or package importable
+by adding the path to its directory to `sys.path`.
 
 ### Content
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ de code source.
 ### Importations et `sys.path`
 
 Il est possible d'importer un module ou un paquet si la liste `sys.path`
-contient le chemin de son dossier. On peut donc rendre un module ou un paquet
-importable en ajoutant le chemin de son dossier à `sys.path`.
+contient le chemin de son dossier parent. On peut donc rendre un module ou un
+paquet importable en ajoutant son parent à `sys.path`.
 
 ### Importations et `sys.modules`
 
@@ -136,8 +136,8 @@ code repository.
 ### Imports and `sys.path`
 
 It is possible to import a module or package if list `sys.path` contains the
-path to its directory. Therefore, you can make a module or package importable
-by adding the path to its directory to `sys.path`.
+path to its parent directory. Therefore, you can make a module or package
+importable by adding its parent to `sys.path`.
 
 ### Imports and `sys.modules`
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,18 @@ Cette bibliothèque offre des manières concises de modifier la liste `sys.path`
 L'utilisateur ne devrait pas avoir besoin d'interagir directement avec cette
 liste.
 
+### Importations et `sys.path`
+
+Il est possible d'importer un module ou un paquet si la liste `sys.path`
+contient le chemin de son dossier. Si un module ou un paquet n'est pas
+importable, il peut le devenir si on ajoute le chemin de son dossier à
+`sys.path`.
+
 ### Contenu
 
-Les fonctions de `syspathmodif` prennent un chemin de type `str` ou
-`pathlib.Path` comme argument.
-Elles convertissent les arguments de type `pathlib.Path` en `str` puisque
-`sys.path` n'est censée contenir que des chaînes de caractères.
+Les fonctions suivantes prennent un chemin de type `str` ou `pathlib.Path`
+comme argument. Elles convertissent les arguments de type `pathlib.Path` en
+`str` puisque `sys.path` n'est censée contenir que des chaînes de caractères.
 
 * `sp_append` ajoute le chemin donné à la fin de `sys.path`.
 * `sp_contains` indique si `sys.path` contient le chemin donné.
@@ -25,8 +31,26 @@ retrait d'un groupe de chemins.
 Il est possible d'utiliser `SysPathBundle` comme un gestionnaire de contexte
 (*context manager*). Dans ce cas, l'instance est vidée à la fin du bloc `with`.
 
+La fonction `sm_contains` prend comme argument un nom de module ou de paquet.
+Elle indique si le dictionnaire `sys.modules` contient ce module ou paquet.
+
 Pour plus d'informations, consultez la documentation et les démos dans le dépôt
 de code source.
+
+### Importations et `sys.modules`
+
+Le dictionnaire `sys.modules` associe des noms (`str`) de module ou de paquet
+au module ou paquet correspondant. Quand un module ou un paquet est importé
+pour la première fois, il est ajouté à `sys.modules`. Puisque le système
+d'importation cherche d'abord les modules et paquets demandés dans
+`sys.modules`, il évite de les charger plus d'une fois. De plus, les modules et
+paquets présents dans `sys.modules` peuvent être importés partout sans qu'on
+modifie `sys.path`.
+
+Sachant cela, on peut déterminer à l'aide de la fonction `sm_contains` si un
+module ou un paquet est déjà importable. Si `sm_contains` renvoie vrai
+(`True`), il n'est pas nécessaire de modifier `sys.path` pour importer le
+module ou le paquet.
 
 ### Dépendances
 
@@ -44,8 +68,9 @@ pip install -r requirements-dev.txt
 ### Démos
 
 Les scripts dans le dossier `demos` montrent comment `syspathmodif` permet
-d'importer un paquet qui est indisponible tant qu'on n'a pas ajouté son chemin
-à `sys.path`. Toutes les démos dépendent du paquet `demo_package`.
+d'importer un paquet qui est indisponible tant qu'on n'a pas ajouté le chemin
+de son dossier à `sys.path`. Toutes les démos dépendent du paquet
+`demo_package`.
 
 `demo_bundle.py` ajoute la racine du dépôt et `demo_package` à `sys.path` à
 l'aide de la classe `SysPathBundle`. Après les importations, la démo annule
@@ -67,6 +92,13 @@ fonction `sp_append`. Après les importations, la démo annule cette modificatio
 python demos/demo_functions.py
 ```
 
+`demo_sm_contains.py` montre un cas où on peut importer un module ou un paquet
+sans ajouter son chemin à `sys.path`. La démo vérifie la présence du module ou
+du paquet dans `sys.modules` à l'aide de la fonction `sm_contains`.
+```
+python demos/demo_sm_contains.py
+```
+
 ### Tests automatiques
 
 Cette commande exécute les tests automatiques.
@@ -79,12 +111,17 @@ pytest tests
 This library offers concise manners to modify list `sys.path`.
 The user should not need to directly interact with that list.
 
+### Imports and `sys.path`
+
+It is possible to import a module or package if list `sys.path` contains the
+path to its directory. A module or package will become importable if the path
+to its directory is added to `sys.path`.
+
 ### Content
 
-The functions in `syspathmodif` take a path of type `str` or `pathlib.Path`
-as an argument.
-They convert arguments of type `pathlib.Path` to `str` since `sys.path` is
-supposed to contain only character strings.
+The following functions take a path of type `str` or `pathlib.Path` as an
+argument. They convert arguments of type `pathlib.Path` to `str` since
+`sys.path` is supposed to contain only character strings.
 
 * `sp_append` appends the given path to the end of `sys.path`.
 * `sp_contains` indicates whether `sys.path` contains the given path.
@@ -97,8 +134,24 @@ Upon instantiation, class `SysPathBundle` stores several paths and adds them to
 `SysPathBundle` can be used as a context manager. In that case, the instance is
 cleared at the `with` block's end.
 
+Function `sm_contains` takes a module's or package's name as an argument. It
+indicates whether dictionary `sys.modules` contains the module or package.
+
 For more information, consult the documentation and the demos in the source
 code repository.
+
+### Imports and `sys.modules`
+
+Dictionary `sys.modules` maps module and package names (`str`) to the
+corresponding module or package. When a module or package is imported for the
+first time, it is added to `sys.modules`. Since the import system looks for the
+requested modules and packages in `sys.modules` first, it avoids loading them
+more than once. Moreover, the modules and packages in `sys.modules` can be
+imported everywhere with no modifications to `sys.path`.
+
+Knowing this, you can determine with function `sm_contains` if a module or
+package is already importable. If `sm_contains` returns `True`, modifiying
+`sys.path` is not required to import the module or package.
 
 ### Dependencies
 
@@ -116,8 +169,15 @@ pip install -r requirements-dev.txt
 ### Demos
 
 The scripts in directory `demos` show how `syspathmodif` allows to import a
-package unavailable unless its path is added to `sys.path`. All demos depend
-on `demo_package`.
+package unavailable unless its directory's path is added to `sys.path`. All
+demos depend on `demo_package`.
+
+`demo_functions.py` adds the repository's root to `sys.path` with function
+`sp_append`. After the imports, the demo undoes this modification with function
+`sp_remove`.
+```
+python demos/demo_functions.py
+```
 
 `demo_bundle.py` adds the repository's root and `demo_package` to `sys.path`
 with class `SysPathBundle`. After the imports, the demo undoes this
@@ -132,11 +192,11 @@ python demos/demo_bundle.py
 python demos/demo_bundle_context.py
 ```
 
-`demo_functions.py` adds the repository's root to `sys.path` with function
-`sp_append`. After the imports, the demo undoes this modification with function
-`sp_remove`.
+`demo_sm_contains.py` shows a case where a module or package can be imported
+without its directory being added to `sys.path`. The demo verifies the module's
+or package's presence in `sys.modules` with function `sm_contains`.
 ```
-python demos/demo_functions.py
+python demos/demo_sm_contains.py
 ```
 
 ### Automated Tests

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ retrait d'un groupe de chemins.
 Il est possible d'utiliser `SysPathBundle` comme un gestionnaire de contexte
 (*context manager*). Dans ce cas, l'instance est vidée à la fin du bloc `with`.
 
-La fonction `sm_contains` prend comme argument un nom de module ou de paquet.
-Elle indique si le dictionnaire `sys.modules` contient ce module ou paquet.
+La fonction `sm_contains` prend comme argument un nom (`str`) de module ou de
+paquet. Elle indique si le dictionnaire `sys.modules` contient ce module ou
+paquet.
 
 Pour plus d'informations, consultez la documentation et les démos dans le dépôt
 de code source.
@@ -132,8 +133,9 @@ Upon instantiation, class `SysPathBundle` stores several paths and adds them to
 `SysPathBundle` can be used as a context manager. In that case, the instance is
 cleared at the `with` block's end.
 
-Function `sm_contains` takes a module's or package's name as an argument. It
-indicates whether dictionary `sys.modules` contains the module or package.
+Function `sm_contains` takes a module's or package's name (`str`) as an
+argument. It indicates whether dictionary `sys.modules` contains the module or
+package.
 
 For more information, consult the documentation and the demos in the source
 code repository.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ requested modules and packages in `sys.modules` first, it avoids loading them
 more than once. Moreover, the modules and packages in `sys.modules` can be
 imported everywhere with no modifications to `sys.path`.
 
-Knowing this, you can determine with function `sm_contains` if a module or
+Knowing this, you can use function `sm_contains` to determine if a module or
 package is already importable. If `sm_contains` returns `True`, modifiying
 `sys.path` is not required to import the module or package.
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@ Cette bibliothèque offre des manières concises de modifier la liste `sys.path`
 L'utilisateur ne devrait pas avoir besoin d'interagir directement avec cette
 liste.
 
-### Importations et `sys.path`
-
-Il est possible d'importer un module ou un paquet si la liste `sys.path`
-contient le chemin de son dossier. On peut donc rendre un module ou un paquet
-importable en ajoutant le chemin de son dossier à `sys.path`.
-
 ### Contenu
 
 Les fonctions suivantes prennent un chemin de type `str` ou `pathlib.Path`
@@ -35,6 +29,12 @@ Elle indique si le dictionnaire `sys.modules` contient ce module ou paquet.
 
 Pour plus d'informations, consultez la documentation et les démos dans le dépôt
 de code source.
+
+### Importations et `sys.path`
+
+Il est possible d'importer un module ou un paquet si la liste `sys.path`
+contient le chemin de son dossier. On peut donc rendre un module ou un paquet
+importable en ajoutant le chemin de son dossier à `sys.path`.
 
 ### Importations et `sys.modules`
 
@@ -110,12 +110,6 @@ pytest tests
 This library offers concise manners to modify list `sys.path`.
 The user should not need to directly interact with that list.
 
-### Imports and `sys.path`
-
-It is possible to import a module or package if list `sys.path` contains the
-path to its directory. Therefore, you can make a module or package importable
-by adding the path to its directory to `sys.path`.
-
 ### Content
 
 The following functions take a path of type `str` or `pathlib.Path` as an
@@ -138,6 +132,12 @@ indicates whether dictionary `sys.modules` contains the module or package.
 
 For more information, consult the documentation and the demos in the source
 code repository.
+
+### Imports and `sys.path`
+
+It is possible to import a module or package if list `sys.path` contains the
+path to its directory. Therefore, you can make a module or package importable
+by adding the path to its directory to `sys.path`.
 
 ### Imports and `sys.modules`
 

--- a/README.md
+++ b/README.md
@@ -91,11 +91,16 @@ utilisant `SysPathBundle` comme un gestionnaire de contexte.
 python demos/demo_bundle_context.py
 ```
 
-`demo_sm_contains.py` montre un cas où on peut importer un module ou un paquet
+`demo_sm_contains1.py` montre un cas où on peut importer un module ou un paquet
 sans ajouter son chemin à `sys.path`. La démo vérifie la présence du module ou
 du paquet dans `sys.modules` à l'aide de la fonction `sm_contains`.
 ```
-python demos/demo_sm_contains.py
+python demos/demo_sm_contains1.py
+```
+
+`demo_sm_contains2.py` montre un autre usage de la fonction `sm_contains`.
+```
+python demos/demo_sm_contains2.py
 ```
 
 ### Tests automatiques
@@ -191,11 +196,16 @@ python demos/demo_bundle.py
 python demos/demo_bundle_context.py
 ```
 
-`demo_sm_contains.py` shows a case where a module or package can be imported
+`demo_sm_contains1.py` shows a case where a module or package can be imported
 without its directory being added to `sys.path`. The demo verifies the module's
 or package's presence in `sys.modules` with function `sm_contains`.
 ```
-python demos/demo_sm_contains.py
+python demos/demo_sm_contains1.py
+```
+
+`demo_sm_contains2.py` shows another use of function `sm_contains`.
+```
+python demos/demo_sm_contains2.py
 ```
 
 ### Automated Tests

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ de code source.
 
 Il est possible d'importer un module ou un paquet si la liste `sys.path`
 contient le chemin de son dossier parent. On peut donc rendre un module ou un
-paquet importable en ajoutant son parent à `sys.path`.
+paquet importable en ajoutant son chemin parent à `sys.path`.
 
 ### Importations et `sys.modules`
 
@@ -67,8 +67,8 @@ pip install -r requirements-dev.txt
 ### Démos
 
 Les scripts dans le dossier `demos` montrent comment `syspathmodif` permet
-d'importer un paquet qui est indisponible tant qu'on n'a pas ajouté le chemin
-de son dossier à `sys.path`. Toutes les démos dépendent du paquet
+d'importer un module ou un paquet qui est indisponible tant qu'on n'a pas
+ajouté son chemin parent à `sys.path`. Toutes les démos dépendent du paquet
 `demo_package`.
 
 `demo_functions.py` ajoute la racine du dépôt à `sys.path` à l'aide de la
@@ -78,9 +78,9 @@ fonction `sp_append`. Après les importations, la démo annule cette modificatio
 python demos/demo_functions.py
 ```
 
-`demo_bundle.py` ajoute la racine du dépôt et `demo_package` à `sys.path` à
-l'aide de la classe `SysPathBundle`. Après les importations, la démo annule
-cette modification en vidant l'instance de `SysPathBundle`.
+`demo_bundle.py` ajoute la racine du dépôt et le dossier `demo_package` à
+`sys.path` à l'aide de la classe `SysPathBundle`. Après les importations, la
+démo annule ces modifications en vidant l'instance de `SysPathBundle`.
 ```
 python demos/demo_bundle.py
 ```
@@ -92,8 +92,8 @@ python demos/demo_bundle_context.py
 ```
 
 `demo_sm_contains1.py` montre un cas où on peut importer un module ou un paquet
-sans ajouter son chemin à `sys.path`. La démo vérifie la présence du module ou
-du paquet dans `sys.modules` à l'aide de la fonction `sm_contains`.
+sans ajouter son chemin parent à `sys.path`. La démo vérifie la présence du
+module ou du paquet dans `sys.modules` à l'aide de la fonction `sm_contains`.
 ```
 python demos/demo_sm_contains1.py
 ```
@@ -142,7 +142,7 @@ code repository.
 
 It is possible to import a module or package if list `sys.path` contains the
 path to its parent directory. Therefore, you can make a module or package
-importable by adding its parent to `sys.path`.
+importable by adding its parent path to `sys.path`.
 
 ### Imports and `sys.modules`
 
@@ -173,8 +173,8 @@ pip install -r requirements-dev.txt
 ### Demos
 
 The scripts in directory `demos` show how `syspathmodif` allows to import a
-package unavailable unless its directory's path is added to `sys.path`. All
-demos depend on `demo_package`.
+module or package unavailable unless its parent path is added to `sys.path`.
+All demos depend on `demo_package`.
 
 `demo_functions.py` adds the repository's root to `sys.path` with function
 `sp_append`. After the imports, the demo undoes this modification with function
@@ -184,8 +184,8 @@ python demos/demo_functions.py
 ```
 
 `demo_bundle.py` adds the repository's root and `demo_package` to `sys.path`
-with class `SysPathBundle`. After the imports, the demo undoes this
-modification by clearing the `SysPathBundle` instance.
+with class `SysPathBundle`. After the imports, the demo undoes these
+modifications by clearing the `SysPathBundle` instance.
 ```
 python demos/demo_bundle.py
 ```
@@ -197,8 +197,8 @@ python demos/demo_bundle_context.py
 ```
 
 `demo_sm_contains1.py` shows a case where a module or package can be imported
-without its directory being added to `sys.path`. The demo verifies the module's
-or package's presence in `sys.modules` with function `sm_contains`.
+without its parent path being added to `sys.path`. The demo verifies the
+module's or package's presence in `sys.modules` with function `sm_contains`.
 ```
 python demos/demo_sm_contains1.py
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ modifie `sys.path`.
 Sachant cela, on peut déterminer à l'aide de la fonction `sm_contains` si un
 module ou un paquet est déjà importable. Si `sm_contains` renvoie vrai
 (`True`), il n'est pas nécessaire de modifier `sys.path` pour importer le
-module ou le paquet.
+module ou le paquet donné.
 
 ### Dépendances
 
@@ -155,7 +155,7 @@ imported everywhere with no modifications to `sys.path`.
 
 Knowing this, you can use function `sm_contains` to determine if a module or
 package is already importable. If `sm_contains` returns `True`, modifiying
-`sys.path` is not required to import the module or package.
+`sys.path` is not required to import the given module or package.
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ d'importer un paquet qui est indisponible tant qu'on n'a pas ajouté le chemin
 de son dossier à `sys.path`. Toutes les démos dépendent du paquet
 `demo_package`.
 
+`demo_functions.py` ajoute la racine du dépôt à `sys.path` à l'aide de la
+fonction `sp_append`. Après les importations, la démo annule cette modification
+à l'aide de la fonction `sp_remove`.
+```
+python demos/demo_functions.py
+```
+
 `demo_bundle.py` ajoute la racine du dépôt et `demo_package` à `sys.path` à
 l'aide de la classe `SysPathBundle`. Après les importations, la démo annule
 cette modification en vidant l'instance de `SysPathBundle`.
@@ -83,13 +90,6 @@ python demos/demo_bundle.py
 utilisant `SysPathBundle` comme un gestionnaire de contexte.
 ```
 python demos/demo_bundle_context.py
-```
-
-`demo_functions.py` ajoute la racine du dépôt à `sys.path` à l'aide de la
-fonction `sp_append`. Après les importations, la démo annule cette modification
-à l'aide de la fonction `sp_remove`.
-```
-python demos/demo_functions.py
 ```
 
 `demo_sm_contains.py` montre un cas où on peut importer un module ou un paquet

--- a/demo_package/__init__.py
+++ b/demo_package/__init__.py
@@ -1,5 +1,7 @@
 from .ajxo import Ajxo
 from .point import Point
 
-# This package does not declare __all__ because the
-# bundle demos need modules ajxo and point to be public.
+__all__ = [
+	Ajxo.__name__,
+	Point.__name__
+]

--- a/demos/demo_sm_contains.py
+++ b/demos/demo_sm_contains.py
@@ -1,0 +1,36 @@
+import sys
+
+from _demo_util import\
+	REPO_ROOT
+
+
+sys.path.append(str(REPO_ROOT))
+from syspathmodif import\
+	SysPathBundle,\
+	sm_contains,\
+	sp_remove
+sp_remove(REPO_ROOT)
+
+
+paths = list()
+
+# To import Ajxo
+if not sm_contains("demo_package"):
+	print("Repository's root added to sys.path")
+	paths.append(REPO_ROOT)
+
+# To import Point
+if not sm_contains("point"):
+	print("demo_package added to sys.path")
+	paths.append(REPO_ROOT/"demo_package")
+
+with SysPathBundle(paths):
+	from demo_package import Ajxo
+	from point import Point
+
+ajxo = Ajxo("a string", [7, 11, 13])
+point = Point(41, 97)
+
+print("\nInstances of imported classes")
+print(ajxo)
+print(point)

--- a/demos/demo_sm_contains.py
+++ b/demos/demo_sm_contains.py
@@ -8,11 +8,23 @@ sys.path.append(str(REPO_ROOT))
 from syspathmodif import\
 	SysPathBundle,\
 	sm_contains,\
+	sp_append,\
 	sp_remove
 sp_remove(REPO_ROOT)
 
 
+def _add_demo_package_to_sys_modules():
+	was_repo_root_added = sp_append(REPO_ROOT)
+	import demo_package
+
+	if was_repo_root_added:
+		sp_remove(REPO_ROOT)
+
+
 paths = list()
+
+# The first conditional block is not executed because of this function.
+_add_demo_package_to_sys_modules()
 
 # To import Ajxo
 if not sm_contains("demo_package"):
@@ -21,7 +33,7 @@ if not sm_contains("demo_package"):
 
 # To import Point
 if not sm_contains("point"):
-	print("demo_package added to sys.path")
+	print("Directory demo_package added to sys.path")
 	paths.append(REPO_ROOT/"demo_package")
 
 with SysPathBundle(paths):

--- a/demos/demo_sm_contains1.py
+++ b/demos/demo_sm_contains1.py
@@ -25,7 +25,8 @@ def _add_demo_package_to_sys_modules():
 
 paths = list()
 
-# The first conditional block is not executed because of this function.
+# This function call prevents the first conditional block's execution.
+# Comment it out and see the result.
 _add_demo_package_to_sys_modules()
 
 # To import Ajxo

--- a/demos/demo_sm_contains1.py
+++ b/demos/demo_sm_contains1.py
@@ -15,6 +15,8 @@ sp_remove(REPO_ROOT)
 
 def _add_demo_package_to_sys_modules():
 	was_repo_root_added = sp_append(REPO_ROOT)
+
+	# The import includes the package in sys.modules.
 	import demo_package
 
 	if was_repo_root_added:

--- a/demos/demo_sm_contains2.py
+++ b/demos/demo_sm_contains2.py
@@ -1,0 +1,38 @@
+import sys
+
+from _demo_util import\
+	REPO_ROOT
+
+
+sys.path.append(str(REPO_ROOT))
+from syspathmodif import\
+	sm_contains,\
+	sp_append,\
+	sp_remove
+
+# This import adds demo_package to sys.modules.
+# Comment it out and see the result.
+import demo_package
+sp_remove(REPO_ROOT)
+
+
+was_repo_root_added = False
+if not sm_contains("demo_package"):
+	was_repo_root_added = sp_append(REPO_ROOT)
+	print(f"Repository root added to sys.path: {was_repo_root_added}")
+
+from demo_package import\
+	Ajxo,\
+	Point
+print("Classes imported from demo_package")
+
+if was_repo_root_added:
+	was_repo_root_removed = sp_remove(REPO_ROOT)
+	print(f"Repository root removed from sys.path: {was_repo_root_removed}")
+
+ajxo = Ajxo("a string", [7, 11, 13])
+point = Point(41, 97)
+
+print("\nInstances of imported classes")
+print(ajxo)
+print(point)

--- a/syspathmodif/__init__.py
+++ b/syspathmodif/__init__.py
@@ -1,6 +1,7 @@
 from .syspathbundle import SysPathBundle
 
 from .individual_paths import\
+	sm_contains,\
 	sp_append,\
 	sp_contains,\
 	sp_remove
@@ -8,6 +9,7 @@ from .individual_paths import\
 
 __all__ = [
 	SysPathBundle.__name__,
+	sm_contains,
 	sp_append.__name__,
 	sp_contains.__name__,
 	sp_remove.__name__

--- a/syspathmodif/__init__.py
+++ b/syspathmodif/__init__.py
@@ -1,7 +1,9 @@
 from .syspathbundle import SysPathBundle
 
+from .sys_modules import\
+	sm_contains
+
 from .individual_paths import\
-	sm_contains,\
 	sp_append,\
 	sp_contains,\
 	sp_remove
@@ -9,7 +11,7 @@ from .individual_paths import\
 
 __all__ = [
 	SysPathBundle.__name__,
-	sm_contains,
+	sm_contains.__name__,
 	sp_append.__name__,
 	sp_contains.__name__,
 	sp_remove.__name__

--- a/syspathmodif/__init__.py
+++ b/syspathmodif/__init__.py
@@ -1,12 +1,13 @@
-from .syspathbundle import SysPathBundle
-
-from .sys_modules import\
-	sm_contains
-
 from .individual_paths import\
 	sp_append,\
 	sp_contains,\
 	sp_remove
+
+from .sys_modules import\
+	sm_contains
+
+from .syspathbundle import\
+	SysPathBundle
 
 
 __all__ = [

--- a/syspathmodif/individual_paths.py
+++ b/syspathmodif/individual_paths.py
@@ -12,8 +12,8 @@ from .individual_paths_no_type_check import\
 def sp_append(some_path):
 	"""
 	Appends the given path to the end of list sys.path if it does not already
-	contain the path. If the path is of type pathlib.Path, it is converted to a
-	string. If the path is None, this function does not change sys.path.
+	contain the path. If the path is None, this function does not change
+	sys.path.
 
 	Args:
 		some_path (str or pathlib.Path): the path to append to sys.path.

--- a/syspathmodif/individual_paths.py
+++ b/syspathmodif/individual_paths.py
@@ -9,6 +9,21 @@ from .individual_paths_no_type_check import\
 	sp_remove_no_type_check
 
 
+def sm_contains(module_name):
+	"""
+	Indicates whether dictionary sys.modules contains the module or package
+	whose name is the argument.
+
+	Args:
+		module_name (str): the name of a module or package.
+
+	Returns:
+		bool: True if sys.modules contains argument module_name, False
+			otherwise.
+	"""
+	return module_name in sys.modules
+
+
 def sp_append(some_path):
 	"""
 	Appends the given path to the end of list sys.path if it does not already
@@ -66,6 +81,7 @@ def sp_remove(some_path):
 
 
 __all__ = [
+	sm_contains.__name__,
 	sp_append.__name__,
 	sp_contains.__name__,
 	sp_remove.__name__

--- a/syspathmodif/individual_paths.py
+++ b/syspathmodif/individual_paths.py
@@ -36,7 +36,7 @@ def sp_append(some_path):
 	Returns:
 		bool: True if some_path was appended to sys.path, False otherwise.
 
-	Throws:
+	Raises:
 		TypeError: if argument some_path is not None and it is not an instance
 			of str or pathlib.Path.
 	"""
@@ -54,7 +54,7 @@ def sp_contains(some_path):
 	Returns:
 		bool: True if sys.path contains argument some_path, False otherwise.
 
-	Throws:
+	Raises:
 		TypeError: if argument some_path is not None and it is not an instance
 			of str or pathlib.Path.
 	"""
@@ -72,7 +72,7 @@ def sp_remove(some_path):
 	Returns:
 		bool: True if some_path was removed from sys.path, False otherwise.
 
-	Throws:
+	Raises:
 		TypeError: if argument some_path is not None and it is not an instance
 			of str or pathlib.Path.
 	"""

--- a/syspathmodif/individual_paths.py
+++ b/syspathmodif/individual_paths.py
@@ -9,21 +9,6 @@ from .individual_paths_no_type_check import\
 	sp_remove_no_type_check
 
 
-def sm_contains(module_name):
-	"""
-	Indicates whether dictionary sys.modules contains the module or package
-	whose name is the argument.
-
-	Args:
-		module_name (str): the name of a module or package.
-
-	Returns:
-		bool: True if sys.modules contains argument module_name, False
-			otherwise.
-	"""
-	return module_name in sys.modules
-
-
 def sp_append(some_path):
 	"""
 	Appends the given path to the end of list sys.path if it does not already
@@ -81,7 +66,6 @@ def sp_remove(some_path):
 
 
 __all__ = [
-	sm_contains.__name__,
 	sp_append.__name__,
 	sp_contains.__name__,
 	sp_remove.__name__

--- a/syspathmodif/sys_modules.py
+++ b/syspathmodif/sys_modules.py
@@ -3,14 +3,15 @@ import sys
 
 def sm_contains(module_name):
 	"""
-	Indicates whether dictionary sys.modules contains the module or package
-	whose name is the argument.
+	Dictionary sys.modules maps module and package names (str) to the
+	corresponding module or package. This function indicates whether
+	sys.modules contains the module or package whose name is the argument.
 
 	Args:
 		module_name (str): the name of a module or package.
 
 	Returns:
-		bool: True if sys.modules contains argument module_name, False
+		bool: True if argument module_name is a key in sys.modules, False
 			otherwise.
 	"""
 	return module_name in sys.modules

--- a/syspathmodif/sys_modules.py
+++ b/syspathmodif/sys_modules.py
@@ -1,0 +1,19 @@
+import sys
+
+
+def sm_contains(module_name):
+	"""
+	Indicates whether dictionary sys.modules contains the module or package
+	whose name is the argument.
+
+	Args:
+		module_name (str): the name of a module or package.
+
+	Returns:
+		bool: True if sys.modules contains argument module_name, False
+			otherwise.
+	"""
+	return module_name in sys.modules
+
+
+__all__ = [sm_contains.__name__]

--- a/syspathmodif/syspathbundle.py
+++ b/syspathmodif/syspathbundle.py
@@ -9,7 +9,7 @@ from .individual_paths_no_type_check import\
 
 class SysPathBundle:
 	"""
-	Upon instantiation, a bundle stores several paths and adds them to
+	Upon instantiation, a bundle stores several paths and adds them to list
 	sys.path. When a bundle is cleared, it erases its content and removes it
 	from sys.path. Thus, this class facilitates adding and removing a group of
 	paths.

--- a/tests/test_sys_modules.py
+++ b/tests/test_sys_modules.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import sys
+
+
+_LOCAL_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _LOCAL_DIR.parent
+
+
+sys.path.append(str(_REPO_ROOT))
+from syspathmodif import\
+	sm_contains,\
+	sp_remove
+sp_remove(_REPO_ROOT)
+
+
+def test_sm_contains_int():
+	assert not sm_contains(17)
+
+
+def test_sm_contains_none():
+	assert not sm_contains(None)
+
+
+def test_sm_contains_pathlib():
+	assert sm_contains("pathlib")
+
+
+def test_sm_contains_sys():
+	assert sm_contains("sys")
+
+
+def test_sm_contains_syspathmodif():
+	assert sm_contains("syspathmodif")
+
+
+def test_sm_contains_strath():
+	# strath is a dependency of syspathmodif.
+	assert sm_contains("strath")

--- a/tests/test_sys_modules.py
+++ b/tests/test_sys_modules.py
@@ -2,15 +2,12 @@ from pathlib import Path
 import sys
 
 
-_LOCAL_DIR = Path(__file__).resolve().parent
-_REPO_ROOT = _LOCAL_DIR.parent
-
-
-sys.path.append(str(_REPO_ROOT))
+repo_root = str(Path(__file__).resolve().parents[1])
+sys.path.append(repo_root)
 from syspathmodif import\
 	sm_contains,\
 	sp_remove
-sp_remove(_REPO_ROOT)
+sp_remove(repo_root)
 
 
 def test_sm_contains_int():


### PR DESCRIPTION
The new function takes a module's or package's name as an argument. It indicates whether dictionary `sys.modules` contains the module or package.

If `sm_contains` returns `True`, modifiying `sys.path` is not required to import the given module or package.