### PR TITLE
Exception handling in `SysPathBundle.clear`

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -36,14 +36,14 @@ jobs:
       - name: Run the second sm_contains demo
         run: python3 demos/demo_sm_contains2.py
   test_bundle_clearing_app_end:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2
       - name: Intall the dependencies
-        run: pip3 install --no-cache-dir -r requirements.txt
+        run: pip install --no-cache-dir -r requirements.txt
       - name: Test the build
-        run: python3 .github/workflows/test_bundle_clearing_app_end.py
+        run: python .github/workflows/test_bundle_clearing_app_end.py
   test_pypi_package_build:
     runs-on: ubuntu-latest
     steps:

--- a/syspathmodif/individual_paths_no_type_check.py
+++ b/syspathmodif/individual_paths_no_type_check.py
@@ -3,8 +3,7 @@
 import sys
 
 
-def sp_append_no_type_check(some_path):
-	# The argument must be a string.
+def sp_append_no_type_check(some_path: str) -> bool:
 	was_path_appended = False
 
 	if some_path not in sys.path and some_path is not None:
@@ -14,8 +13,7 @@ def sp_append_no_type_check(some_path):
 	return was_path_appended
 
 
-def sp_remove_no_type_check(some_path):
-	# The argument must be a string.
+def sp_remove_no_type_check(some_path: str) -> bool:
 	was_path_removed = False
 
 	try:

--- a/syspathmodif/individual_paths_no_type_check.py
+++ b/syspathmodif/individual_paths_no_type_check.py
@@ -4,6 +4,7 @@ import sys
 
 
 def sp_append_no_type_check(some_path):
+	# The argument must be a string.
 	was_path_appended = False
 
 	if some_path not in sys.path and some_path is not None:
@@ -14,12 +15,14 @@ def sp_append_no_type_check(some_path):
 
 
 def sp_remove_no_type_check(some_path):
+	# The argument must be a string.
 	was_path_removed = False
 
 	try:
-		sys.path.remove(some_path) # ValueError if argument not in list
+		sys.path.remove(some_path)
 		was_path_removed = True
 	except ValueError:
+		# If some_path is not in sys.path.
 		pass
 
 	return was_path_removed

--- a/syspathmodif/syspathbundle.py
+++ b/syspathmodif/syspathbundle.py
@@ -111,7 +111,6 @@ class SysPathBundle:
 			path = ensure_path_is_str(path, True)
 
 			if sp_append_no_type_check(path):
-				# Any path in self._content is a string.
 				self._content.append(path)
 
 

--- a/syspathmodif/syspathbundle.py
+++ b/syspathmodif/syspathbundle.py
@@ -78,16 +78,15 @@ class SysPathBundle:
 		"""
 		Erases this bundle's content and removes it from sys.path.
 		"""
-		while len(self._content) > 0:
-			path = self._content.pop()
-
-			try:
+		try:
+			while len(self._content) > 0:
+				path = self._content.pop()
 				sp_remove_no_type_check(path)
-			except AttributeError:
-				# If a bundle is cleared by the destructor when
-				# the application ends, sys.path can be None.
-				self._content.clear()
-				break
+
+		except AttributeError:
+			# If a bundle is cleared by the destructor when
+			# the application ends, sys.path can be None.
+			self._content.clear()
 
 	def contains(self, some_path):
 		"""


### PR DESCRIPTION
The `try` block in `SysPathBundle.clear` contains the `while` loop rather than the other way around. This change prevents the repeated creation of exception handling structures.

Type hints in the functions of module `individual_paths_no_type_check.py` clarify that their argument must be a string.

CI job `test_bundle_clearing_app_end` runs on `windows-latest` because the issue occurs on Windows.