### PR TITLE
Documentation fixes

### DIFF
--- a/.github/workflows/test_bundle_clearing_app_end.py
+++ b/.github/workflows/test_bundle_clearing_app_end.py
@@ -17,7 +17,7 @@ _REPO_ROOT = _LOCAL_DIR.parents[1]
 _LIB_DIR = _REPO_ROOT/"syspathmodif"
 
 
-sys.path.append(str(_REPO_ROOT))
+sys.path.insert(0, str(_REPO_ROOT))
 from syspathmodif import\
 	SysPathBundle,\
 	sp_remove

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Dictionary `sys.modules` maps module and package names (`str`) to the
 corresponding module or package. The import system uses it as a cache; any
 module or package imported for the first time is stored in it. Since the import
 system looks for the requested modules and packages in `sys.modules` first, the
-modules and packages in `sys.modules` can be imported everywhere with no
+modules and packages that it contains can be imported everywhere with no
 modifications to `sys.path`.
 
 Knowing this, you can use function `sm_contains` to determine if a module or

--- a/README.md
+++ b/README.md
@@ -41,12 +41,11 @@ paquet importable en ajoutant son chemin parent à `sys.path`.
 ### Importations et `sys.modules`
 
 Le dictionnaire `sys.modules` associe des noms (`str`) de module ou de paquet
-au module ou paquet correspondant. Quand un module ou un paquet est importé
-pour la première fois, il est ajouté à `sys.modules`. Puisque le système
-d'importation cherche d'abord les modules et paquets demandés dans
-`sys.modules`, il évite de les charger plus d'une fois. De plus, les modules et
-paquets présents dans `sys.modules` peuvent être importés partout sans qu'on
-modifie `sys.path`.
+au module ou paquet correspondant. Le système d'importation l'utilise comme
+cache; tout module ou paquet importé pour la première fois y est conservé.
+Puisque le système d'importation cherche d'abord les modules et paquets
+demandés dans `sys.modules`, les modules et paquets qu'il contient peuvent être
+importés partout sans qu'on modifie `sys.path`.
 
 Sachant cela, on peut déterminer à l'aide de la fonction `sm_contains` si un
 module ou un paquet est déjà importable. Si `sm_contains` renvoie vrai
@@ -152,11 +151,11 @@ importable by adding its parent path to `sys.path`.
 ### Imports and `sys.modules`
 
 Dictionary `sys.modules` maps module and package names (`str`) to the
-corresponding module or package. When a module or package is imported for the
-first time, it is added to `sys.modules`. Since the import system looks for the
-requested modules and packages in `sys.modules` first, it avoids loading them
-more than once. Moreover, the modules and packages in `sys.modules` can be
-imported everywhere with no modifications to `sys.path`.
+corresponding module or package. The import system uses it as a cache; any
+module or package imported for the first time is stored in it. Since the import
+system looks for the requested modules and packages in `sys.modules` first, the
+modules and packages in `sys.modules` can be imported everywhere with no
+modifications to `sys.path`.
 
 Knowing this, you can use function `sm_contains` to determine if a module or
 package is already importable. If `sm_contains` returns `True`, modifiying

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ paquet importable en ajoutant son chemin parent à `sys.path`.
 
 Le dictionnaire `sys.modules` associe des noms (`str`) de module ou de paquet
 au module ou paquet correspondant. Le système d'importation l'utilise comme
-cache; tout module ou paquet importé pour la première fois y est conservé.
+cache; tout module ou paquet importé pour la première fois y est ajouté.
 Puisque le système d'importation cherche d'abord les modules et paquets
 demandés dans `sys.modules`, les modules et paquets qu'il contient peuvent être
 importés partout sans qu'on modifie `sys.path`.

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ comme argument. Elles convertissent les arguments de type `pathlib.Path` en
 * `sp_prepend` ajoute le chemin donné au début de `sys.path`.
 * `sp_remove` enlève le chemin donné de `sys.path`.
 
-Dès son instanciation, la classe `SysPathBundle` contient plusieurs chemins et
-les ajoute au début de `sys.path`. Quand on vide (*clear*) une instance, elle
-efface son contenu et l'enlève de `sys.path`. Ainsi, cette classe facilite
-l'ajout et le retrait d'un groupe de chemins.
+Au moment de sa création, une instance de `SysPathBundle` contient plusieurs
+chemins et les ajoute au début de `sys.path`. Quand on vide (*clear*) une
+instance, elle efface son contenu et l'enlève de `sys.path`. Ainsi, cette
+classe facilite l'ajout et le retrait d'un groupe de chemins.
 
 Il est possible d'utiliser `SysPathBundle` comme un gestionnaire de contexte
 (*context manager*). Dans ce cas, l'instance est vidée à la fin du bloc `with`.
@@ -127,7 +127,7 @@ argument. They convert arguments of type `pathlib.Path` to `str` since
 * `sp_prepend` adds the given path to the beginning of `sys.path`.
 * `sp_remove` removes the given path from `sys.path`.
 
-Upon instantiation, class `SysPathBundle` stores several paths and prepends
+Upon creation, a `SysPathBundle` instance stores several paths and prepends
 them to `sys.path`. When a bundle is cleared, it erases its content and removes
 it from `sys.path`. Thus, this class facilitates adding and removing a group of
 paths.

--- a/demos/demo_bundle.py
+++ b/demos/demo_bundle.py
@@ -18,10 +18,10 @@ print(f"Package: {_PACKAGE_DIR}")
 
 
 # Imports from syspathmodif are performed here.
-sys.path.append(str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT))
 
 print_sys_path(
-	"\nRepository root appended to sys.path to import package syspathmodif")
+	"\nRepository root prepended to sys.path to import package syspathmodif")
 
 from syspathmodif import\
 	SysPathBundle,\

--- a/demos/demo_bundle_context.py
+++ b/demos/demo_bundle_context.py
@@ -18,10 +18,10 @@ print(f"Package: {_PACKAGE_DIR}")
 
 
 # Imports from syspathmodif are performed here.
-sys.path.append(str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT))
 
 print_sys_path(
-	"\nRepository root appended to sys.path to import package syspathmodif")
+	"\nRepository root prepended to sys.path to import package syspathmodif")
 
 from syspathmodif import\
 	SysPathBundle,\

--- a/demos/demo_functions.py
+++ b/demos/demo_functions.py
@@ -15,9 +15,9 @@ print(f"Repository root: {REPO_ROOT}")
 
 
 # Imports from syspathmodif are performed here.
-sys.path.append(str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT))
 print_sys_path(
-	"\nRepository root appended to sys.path to import package syspathmodif")
+	"\nRepository root prepended to sys.path to import package syspathmodif")
 
 from syspathmodif import\
 	sp_contains,\

--- a/demos/demo_sm_contains1.py
+++ b/demos/demo_sm_contains1.py
@@ -4,7 +4,7 @@ from _demo_util import\
 	REPO_ROOT
 
 
-sys.path.append(str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT))
 from syspathmodif import\
 	SysPathBundle,\
 	sm_contains,\

--- a/demos/demo_sm_contains2.py
+++ b/demos/demo_sm_contains2.py
@@ -4,7 +4,7 @@ from _demo_util import\
 	REPO_ROOT
 
 
-sys.path.append(str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT))
 from syspathmodif import\
 	sm_contains,\
 	sp_append,\

--- a/syspathmodif/syspathbundle.py
+++ b/syspathmodif/syspathbundle.py
@@ -84,7 +84,7 @@ class SysPathBundle:
 				sp_remove_no_type_check(path)
 
 		except AttributeError:
-			# If a bundle is cleared by the destructor when
+			# If the destructor clears a bundle when
 			# the application ends, sys.path can be None.
 			self._content.clear()
 

--- a/tests/test_individual_paths.py
+++ b/tests/test_individual_paths.py
@@ -20,7 +20,7 @@ def _reset_sys_path():
 	sys.path = list(_INIT_SYS_PATH)
 
 
-sys.path.append(str(_REPO_ROOT))
+sys.path.insert(0, str(_REPO_ROOT))
 from syspathmodif import\
 	sp_append,\
 	sp_contains,\

--- a/tests/test_sys_modules.py
+++ b/tests/test_sys_modules.py
@@ -3,7 +3,7 @@ import sys
 
 
 repo_root = str(Path(__file__).resolve().parents[1])
-sys.path.append(repo_root)
+sys.path.insert(0, repo_root)
 from syspathmodif import\
 	sm_contains,\
 	sp_remove

--- a/tests/test_syspathbundle.py
+++ b/tests/test_syspathbundle.py
@@ -16,7 +16,7 @@ def _reset_sys_path():
 	sys.path = list(_INIT_SYS_PATH)
 
 
-sys.path.append(str(_REPO_ROOT))
+sys.path.insert(0, str(_REPO_ROOT))
 from syspathmodif import SysPathBundle
 _reset_sys_path()
 


### PR DESCRIPTION
* `README.md` tells that `sys.modules` is a cache.
* `README.md` tells that `SysPathBundle` instances, not the class, act.
* `README.md` recieved other corrections.
* A comment about `SysPathBundle` was rewritten in the active voice.
* The demos and the tests prepend the repository's root to `sys.path` to import `syspathmodif`.