### PR TITLE
[24] Distinction between modules and packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,32 +25,29 @@ classe facilite l'ajout et le retrait d'un groupe de chemins.
 Il est possible d'utiliser `SysPathBundle` comme un gestionnaire de contexte
 (*context manager*). Dans ce cas, l'instance est vidée à la fin du bloc `with`.
 
-La fonction `sm_contains` prend comme argument un nom (`str`) de module ou de
-paquet. Elle indique si le dictionnaire `sys.modules` contient ce module ou
-paquet.
+La fonction `sm_contains` prend comme argument un nom (`str`) de module. Elle
+indique si le dictionnaire `sys.modules` contient ce module.
 
 Pour plus d'informations, consultez la documentation et les démos dans le dépôt
 de code source.
 
 ### Importations et `sys.path`
 
-Il est possible d'importer un module ou un paquet si la liste `sys.path`
-contient le chemin de son dossier parent. On peut donc rendre un module ou un
-paquet importable en ajoutant son chemin parent à `sys.path`.
+Il est possible d'importer un module si la liste `sys.path` contient le chemin
+de son dossier parent. On peut donc rendre un module importable en ajoutant son
+chemin parent à `sys.path`.
 
 ### Importations et `sys.modules`
 
-Le dictionnaire `sys.modules` associe des noms (`str`) de module ou de paquet
-au module ou paquet correspondant. Le système d'importation l'utilise comme
-cache; tout module ou paquet importé pour la première fois y est ajouté.
-Puisque le système d'importation cherche d'abord les modules et paquets
-demandés dans `sys.modules`, les modules et paquets qu'il contient peuvent être
-importés partout sans qu'on modifie `sys.path`.
+Le dictionnaire `sys.modules` associe des noms (`str`) de module au module
+correspondant. Le système d'importation l'utilise comme cache; tout module
+importé pour la première fois y est conservé. Puisque le système d'importation
+cherche d'abord les modules demandés dans `sys.modules`, les modules qu'il
+contient peuvent être importés partout sans qu'on modifie `sys.path`.
 
 Sachant cela, on peut déterminer à l'aide de la fonction `sm_contains` si un
-module ou un paquet est déjà importable. Si `sm_contains` renvoie vrai
-(`True`), il n'est pas nécessaire de modifier `sys.path` pour importer le
-module ou le paquet donné.
+module est déjà importable. Si `sm_contains` renvoie vrai (`True`), il n'est
+pas nécessaire de modifier `sys.path` pour importer le module donné.
 
 ### Dépendances
 
@@ -68,9 +65,8 @@ pip install -r requirements-dev.txt
 ### Démos
 
 Les scripts dans le dossier `demos` montrent comment `syspathmodif` permet
-d'importer un module ou un paquet qui est indisponible tant qu'on n'a pas
-ajouté son chemin parent à `sys.path`. Toutes les démos dépendent du paquet
-`demo_package`.
+d'importer un module qui est indisponible tant qu'on n'a pas ajouté son chemin
+parent à `sys.path`. Toutes les démos dépendent du paquet `demo_package`.
 
 `demo_functions.py` ajoute la racine du dépôt à `sys.path` à l'aide de la
 fonction `sp_prepend`. Après les importations, la démo annule cette
@@ -92,9 +88,9 @@ utilisant `SysPathBundle` comme un gestionnaire de contexte.
 python demos/demo_bundle_context.py
 ```
 
-`demo_sm_contains1.py` montre un cas où on peut importer un module ou un paquet
-sans ajouter son chemin parent à `sys.path`. La démo vérifie la présence du
-module ou du paquet dans `sys.modules` à l'aide de la fonction `sm_contains`.
+`demo_sm_contains1.py` montre un cas où on peut importer un module sans ajouter
+son chemin parent à `sys.path`. La démo vérifie la présence du module dans
+`sys.modules` à l'aide de la fonction `sm_contains`.
 ```
 python demos/demo_sm_contains1.py
 ```

--- a/README.md
+++ b/README.md
@@ -135,31 +135,29 @@ paths.
 `SysPathBundle` can be used as a context manager. In that case, the instance is
 cleared at the `with` block's end.
 
-Function `sm_contains` takes a module's or package's name (`str`) as an
-argument. It indicates whether dictionary `sys.modules` contains the module or
-package.
+Function `sm_contains` takes a module's name (`str`) as an argument. It
+indicates whether dictionary `sys.modules` contains the module.
 
 For more information, consult the documentation and the demos in the source
 code repository.
 
 ### Imports and `sys.path`
 
-It is possible to import a module or package if list `sys.path` contains the
-path to its parent directory. Therefore, you can make a module or package
-importable by adding its parent path to `sys.path`.
+It is possible to import a module if list `sys.path` contains the path to its
+parent directory. Therefore, you can make a module importable by adding its
+parent path to `sys.path`.
 
 ### Imports and `sys.modules`
 
-Dictionary `sys.modules` maps module and package names (`str`) to the
-corresponding module or package. The import system uses it as a cache; any
-module or package imported for the first time is stored in it. Since the import
-system looks for the requested modules and packages in `sys.modules` first, the
-modules and packages that it contains can be imported everywhere with no
-modifications to `sys.path`.
+Dictionary `sys.modules` maps module names (`str`) to the corresponding module.
+The import system uses it as a cache; any module imported for the first time is
+stored in it. Since the import system looks for the requested modules in
+`sys.modules` first, the modules that it contains can be imported everywhere
+with no modifications to `sys.path`.
 
-Knowing this, you can use function `sm_contains` to determine if a module or
-package is already importable. If `sm_contains` returns `True`, modifiying
-`sys.path` is not required to import the given module or package.
+Knowing this, you can use function `sm_contains` to determine if a module is
+already importable. If `sm_contains` returns `True`, modifiying `sys.path` is
+not required to import the given module.
 
 ### Dependencies
 
@@ -177,8 +175,8 @@ pip install -r requirements-dev.txt
 ### Demos
 
 The scripts in directory `demos` show how `syspathmodif` allows to import a
-module or package unavailable unless its parent path is added to `sys.path`.
-All demos depend on `demo_package`.
+module unavailable unless its parent path is added to `sys.path`. All demos
+depend on `demo_package`.
 
 `demo_functions.py` adds the repository's root to `sys.path` with function
 `sp_prepend`. After the imports, the demo undoes this modification with
@@ -200,9 +198,9 @@ python demos/demo_bundle.py
 python demos/demo_bundle_context.py
 ```
 
-`demo_sm_contains1.py` shows a case where a module or package can be imported
-without its parent path being added to `sys.path`. The demo verifies the
-module's or package's presence in `sys.modules` with function `sm_contains`.
+`demo_sm_contains1.py` shows a case where a module can be imported without its
+parent path being added to `sys.path`. The demo verifies the module's presence
+in `sys.modules` with function `sm_contains`.
 ```
 python demos/demo_sm_contains1.py
 ```

--- a/syspathmodif/sys_modules.py
+++ b/syspathmodif/sys_modules.py
@@ -3,12 +3,12 @@ import sys
 
 def sm_contains(module_name: str) -> bool:
 	"""
-	Dictionary sys.modules maps module and package names (str) to the
-	corresponding module or package. This function indicates whether
-	sys.modules contains the module or package whose name is the argument.
+	Dictionary sys.modules maps module names (str) to the corresponding module.
+	This function indicates whether sys.modules contains the module whose name
+	is the argument.
 
 	Args:
-		module_name: the name of a module or package.
+		module_name: the name of a module.
 
 	Returns:
 		bool: True if argument module_name is a key in sys.modules, False


### PR DESCRIPTION
Every instance of the module/package distinction was removed.

Close #24