### PR TITLE
[31] Attribute `_cleared_on_del` created first.

### DIFF
--- a/syspathmodif/individual_paths.py
+++ b/syspathmodif/individual_paths.py
@@ -11,7 +11,7 @@ from .individual_paths_no_type_check import\
 	sp_remove_no_type_check
 
 
-def sp_append(some_path: str|Path) -> bool:
+def sp_append(some_path: str | Path) -> bool:
 	"""
 	Adds the given path to the end of list sys.path if it does not already
 	contain the path. If the path is None, this function does not change
@@ -31,7 +31,7 @@ def sp_append(some_path: str|Path) -> bool:
 	return sp_append_no_type_check(some_path)
 
 
-def sp_contains(some_path: str|Path) -> bool:
+def sp_contains(some_path: str | Path) -> bool:
 	"""
 	Indicates whether list sys.path contains the given path.
 
@@ -49,7 +49,7 @@ def sp_contains(some_path: str|Path) -> bool:
 	return some_path in sys.path
 
 
-def sp_prepend(some_path: str|Path) -> bool:
+def sp_prepend(some_path: str | Path) -> bool:
 	"""
 	Adds the given path to the beginning of list sys.path if it does not
 	already contain the path. If the path is None, this function does not
@@ -69,7 +69,7 @@ def sp_prepend(some_path: str|Path) -> bool:
 	return sp_prepend_no_type_check(some_path)
 
 
-def sp_remove(some_path: str|Path) -> bool:
+def sp_remove(some_path: str | Path) -> bool:
 	"""
 	Removes the given path from list sys.path if it contains the path.
 

--- a/syspathmodif/syspathbundle.py
+++ b/syspathmodif/syspathbundle.py
@@ -22,18 +22,18 @@ class SysPathBundle:
 
 	with SysPathBundle(("path/to/module", "path/to/package")):
 	
-	The constructor can set a bundle to be cleared by the destructor. This
+	The initializer can set a bundle to be cleared by the destructor. This
 	should not be done for a bundle used as a context manager as exiting the
 	with block clears the bundle anyway.
 	"""
 
 	def __init__(
 			self,
-			content: Iterable[str|Path],
+			content: Iterable[str | Path],
 			cleared_on_del: bool = False
 		) -> None:
 		"""
-		The constructor needs the paths to store in this bundle and prepend to
+		The initializer needs the paths to store in this bundle and prepend to
 		sys.path. If a path in argument content is None or is already in
 		sys.path, the bundle will not store it.
 
@@ -47,10 +47,10 @@ class SysPathBundle:
 			TypeError: if a path is not None and not of type str or
 				pathlib.Path.
 		"""
+		self._cleared_on_del = cleared_on_del
+
 		self._content = list()
 		self._fill_content(content) # Can raise TypeError.
-
-		self._cleared_on_del = cleared_on_del
 
 	def __del__(self) -> None:
 		"""
@@ -94,7 +94,7 @@ class SysPathBundle:
 			# the application ends, sys.path can be None.
 			self._content.clear()
 
-	def contains(self, some_path: str|Path) -> bool:
+	def contains(self, some_path: str | Path) -> bool:
 		"""
 		Indicates whether this bundle contains the given path.
 
@@ -111,7 +111,7 @@ class SysPathBundle:
 		some_path = ensure_path_is_str(some_path, True)
 		return some_path in self._content
 
-	def _fill_content(self, content: Iterable[str|Path]) -> None:
+	def _fill_content(self, content: Iterable[str | Path]) -> None:
 		for path in content:
 			path = ensure_path_is_str(path, True)
 

--- a/tests/test_syspathbundle.py
+++ b/tests/test_syspathbundle.py
@@ -18,7 +18,7 @@ reset_sys_path()
 
 
 def _assert_path_in_sys_path(
-		some_path: str|Path,
+		some_path: str | Path,
 		is_in_sys_path: bool
 	) -> None:
 	some_path = ensure_path_is_str(some_path, True)
@@ -26,7 +26,7 @@ def _assert_path_in_sys_path(
 
 
 def _assert_path_is_present(
-		some_path: str|Path,
+		some_path: str | Path,
 		bundle: SysPathBundle,
 		is_in_sys_path: bool,
 		is_in_bundle: bool


### PR DESCRIPTION
In `SysPathBundle.__init__`, attribute `_cleared_on_del` is created before the bundle's content is initialized. This ensures that the attribute will exist even if `SysPathBundle._fill_content` raises a `TypeError`.

Close #31